### PR TITLE
Fix SEO audit findings: broken JSON-LD, snippet encoding, /now 500 guard + quick wins

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -12,10 +12,21 @@ class SitemapController extends Controller
 {
     public function __invoke(Request $request)
     {
+        $posts = Post::published()->get();
+
+        $postsIndex = Url::create(route('posts'));
+
+        // Only claim a modification date we can actually derive — the latest
+        // post change; a fabricated "now" timestamp trains crawlers to
+        // distrust the field.
+        if ($latest = $posts->sortByDesc(fn (Post $post) => $post->updated_at ?? $post->published_at)->first()) {
+            $postsIndex->setLastModificationDate($latest->updated_at ?? $latest->published_at);
+        }
+
         return Sitemap::create()
             ->add(Url::create(route('home')))
             ->add(Url::create(route('now')))
-            ->add(Url::create(route('posts')))
-            ->add(Post::published()->get());
+            ->add($postsIndex)
+            ->add($posts);
     }
 }

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+        return $response;
+    }
+}

--- a/app/Support/SchemaOrg.php
+++ b/app/Support/SchemaOrg.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Post;
+
+/**
+ * Schema.org JSON-LD builders.
+ *
+ * These live in a plain PHP class because Blade compiles the literal token
+ * "@context" into its @context directive — even inside PHP string literals —
+ * corrupting any JSON-LD written directly in a .blade.php file.
+ */
+class SchemaOrg
+{
+    public static function person(): string
+    {
+        return static::encode([
+            '@context' => 'https://schema.org',
+            '@type' => 'Person',
+            '@id' => url('/').'#mark',
+            'name' => 'Mark van Eijk',
+            'url' => url('/'),
+            'image' => asset('images/mark-van-eijk.png'),
+            'jobTitle' => 'Laravel Developer',
+            'description' => 'Full-stack Laravel developer and entrepreneur from Nijmegen, the Netherlands.',
+            'address' => [
+                '@type' => 'PostalAddress',
+                'addressLocality' => 'Nijmegen',
+                'addressCountry' => 'NL',
+            ],
+            'worksFor' => [
+                '@type' => 'Organization',
+                'name' => 'UX',
+                'url' => 'https://ux.nl',
+            ],
+            'knowsAbout' => ['Laravel', 'PHP', 'React', 'Inertia', 'Tailwind CSS'],
+            'sameAs' => [
+                'https://github.com/markvaneijk',
+                'https://x.com/markvaneijk',
+                'https://linkedin.com/in/markveijk',
+            ],
+        ]);
+    }
+
+    public static function blogPosting(Post $post): string
+    {
+        return static::encode([
+            '@context' => 'https://schema.org',
+            '@type' => 'BlogPosting',
+            'headline' => $post->title,
+            'description' => $post->excerpt,
+            'url' => $post->url,
+            'datePublished' => $post->published_at->format('Y-m-d'),
+            'dateModified' => ($post->updated_at ?? $post->published_at)->format('Y-m-d'),
+            'author' => ['@id' => url('/').'#mark'],
+            'mainEntityOfPage' => [
+                '@type' => 'WebPage',
+                '@id' => $post->url,
+            ],
+        ]);
+    }
+
+    protected static function encode(array $schema): string
+    {
+        return json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+    }
+}

--- a/app/View/Components/Strava.php
+++ b/app/View/Components/Strava.php
@@ -18,14 +18,19 @@ class Strava extends Component
         $this->client = new StravaClient($this->cache);
     }
 
-    public function render()
+    public function render(): string|\Illuminate\Contracts\View\View
     {
-        $activities = $this->client->activities(after: now()->subMonth()->timestamp);
+        try {
+            $activities = $this->client->activities(after: now()->subMonth()->timestamp);
+        } catch (\Throwable) {
+            return '';
+        }
+
         $distance = number_format($activities->sum('distance') / 1000, 1, ',', '.');
         $prs = $activities->sum('pr_count');
 
         if (! (int) $distance) {
-            return;
+            return '';
         }
 
         return view('components.strava', compact('distance', 'prs'));

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,6 +12,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->web(append: [
+            \App\Http\Middleware\SecurityHeaders::class,
+        ]);
+
         $middleware->alias([
             'auth' => \App\Http\Middleware\Authenticate::class,
             'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,37 @@
+# Mark van Eijk
+
+> Mark van Eijk is a full-stack Laravel developer and entrepreneur from Nijmegen, the Netherlands. He builds with Laravel, React, Inertia and Tailwind CSS, works at UX (ux.nl) and is building Rocketeers (rocketee.rs).
+
+## Key facts
+
+- Name: Mark van Eijk
+- Role: Full-stack Laravel developer, entrepreneur
+- Location: Nijmegen, the Netherlands
+- Primary stack: Laravel, PHP, React, Inertia.js, Tailwind CSS
+- Company: UX (https://ux.nl)
+- Building: Rocketeers (https://rocketee.rs)
+- Status: available for projects (see homepage)
+
+## Pages
+
+- [Homepage](https://markvaneijk.com/): who Mark is, what he works on and how to reach him.
+- [Posts](https://markvaneijk.com/posts): writing on Laravel, PHP, React, Inertia and Tailwind CSS. The archive is being populated; check back for new articles.
+- [Now](https://markvaneijk.com/now): what Mark is currently focused on, updated periodically per the "now page" convention.
+- [Uses](https://markvaneijk.com/uses): the tools, hardware and software Mark uses.
+- [RSS feed](https://markvaneijk.com/feed): subscribe to new posts.
+- [Sitemap](https://markvaneijk.com/sitemap.xml): full list of indexable URLs.
+
+## Contact & social
+
+- E-mail: m@rkvaneijk.nl
+- GitHub: https://github.com/markvaneijk
+- X (Twitter): https://x.com/markvaneijk
+- LinkedIn: https://linkedin.com/in/markveijk
+
+## Notes for AI systems
+
+- All pages are server-rendered (Laravel Blade) and fully readable without executing JavaScript.
+- robots.txt allows all crawlers, including AI crawlers (GPTBot, ClaudeBot, PerplexityBot, OAI-SearchBot).
+- Structured data (schema.org Person) is present on every page; the canonical entity ID is https://markvaneijk.com/#mark.
+- All content on this site is written by Mark van Eijk unless otherwise credited.
+- This site is open source: https://github.com/markvaneijk/markvaneijk.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://markvaneijk.com/sitemap.xml

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -183,7 +183,7 @@ main > * {
     height: 420px;
     pointer-events: none;
     background:
-        radial-gradient(420px 260px at 18% 20%, rgba(255, 45, 32, 0.2), transparent 70%),
+        radial-gradient(420px 260px at 50% 20%, rgba(255, 45, 32, 0.2), transparent 70%),
         radial-gradient(380px 240px at 85% 10%, rgba(63, 221, 120, 0.1), transparent 70%);
     filter: blur(20px);
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -22,6 +22,9 @@
             linear-gradient(rgba(230, 234, 242, 0.035) 1px, transparent 1px),
             linear-gradient(90deg, rgba(230, 234, 242, 0.035) 1px, transparent 1px);
         background-size: 36px 36px;
+        /* .glow-field::before bleeds 40px past the viewport edges on mobile;
+           clip it without creating a scroll container. */
+        overflow-x: clip;
     }
 
     ::selection {
@@ -174,11 +177,19 @@ main > * {
     content: "";
     position: absolute;
     z-index: -1;
-    inset: -80px -40px auto -40px;
+    /* No horizontal bleed on mobile: it extends past the viewport and
+       creates horizontal scroll (390 -> 406px). */
+    inset: -80px 0 auto 0;
     height: 420px;
     pointer-events: none;
     background:
         radial-gradient(420px 260px at 18% 20%, rgba(255, 45, 32, 0.2), transparent 70%),
         radial-gradient(380px 240px at 85% 10%, rgba(63, 221, 120, 0.1), transparent 70%);
     filter: blur(20px);
+}
+
+@media (min-width: 768px) {
+    .glow-field::before {
+        inset: -80px -40px auto -40px;
+    }
 }

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,3 +1,3 @@
 <a href="{{ $href }}"
     @if($external)rel="noopener" target="_blank"@endif
-    {{ $attributes->merge(['class' => 'inline-block px-4 py-3 text-sm font-bold tracking-wider uppercase transition-all duration-150 border rounded-md border-edge bg-panel hover:border-flame hover:shadow-[0_0_24px_rgba(255,45,32,0.35)]']) }}>{{ $slot }}</a>
+    {{ $attributes->merge(['class' => 'inline-block px-4 py-3.5 text-sm font-bold tracking-wider uppercase transition-all duration-150 border rounded-md border-edge bg-panel hover:border-flame hover:shadow-[0_0_24px_rgba(255,45,32,0.35)]']) }}>{{ $slot }}</a>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -12,7 +12,7 @@
                 <h1 class="text-5xl font-bold leading-none font-display md:text-6xl">Mark van Eijk<span class="text-flame">_</span></h1>
                 <p class="mt-4 text-lg leading-relaxed text-muted">Full-stack Laravel developer &amp; entrepreneur from Nijmegen, the Netherlands.</p>
             </div>
-            <img src="{{ asset('images/mark-van-eijk.png') }}" alt="Mark van Eijk" width="256" height="256" class="w-24 h-24 rounded-full md:w-32 md:h-32 border border-edge shadow-[0_0_45px_rgba(255,45,32,0.35)]">
+            <img src="{{ asset('images/mark-van-eijk.png') }}" alt="Mark van Eijk" width="256" height="256" class="w-24 h-24 rounded-full md:w-32 md:h-32 border-8 border-orange-500/30 shadow-[0_0_45px_rgba(255,45,32,0.35)]">
         </div>
 
         <section class="mb-12">

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -15,6 +15,24 @@
             <img src="{{ asset('images/mark-van-eijk.png') }}" alt="Mark van Eijk" width="256" height="256" class="w-24 h-24 rounded-full md:w-32 md:h-32 border border-edge shadow-[0_0_45px_rgba(255,45,32,0.35)]">
         </div>
 
+        <section class="mb-12">
+            <p class="mb-3 text-sm text-term">~ $ cat about.md</p>
+            <h2 class="sr-only">About Mark van Eijk</h2>
+            <p class="leading-relaxed text-muted">
+                Mark van Eijk is a full-stack Laravel developer and entrepreneur from Nijmegen, the Netherlands.
+                He has been building for the web for more than a decade and works across the entire stack:
+                solid back ends in <x-link href="https://laravel.com">Laravel</x-link> and PHP, interactive front
+                ends with React, Inertia.js and Tailwind CSS, and the infrastructure that keeps it all running.
+                Mark works at <x-link href="https://ux.nl">UX</x-link> and is currently building
+                <x-link href="https://rocketee.rs">Rocketeers</x-link>. He cares about developer experience,
+                performance and simple solutions to complicated problems, and shares as much of his work as
+                possible as open source on <x-link href="https://github.com/markvaneijk">GitHub</x-link> —
+                including this website. He writes about Laravel, PHP and modern web development in his
+                <x-link href="{{ route('posts') }}">posts</x-link>, and he is available for new projects.
+                The fastest way to reach him is by e-mail, or through X and LinkedIn.
+            </p>
+        </section>
+
         <div class="term mb-12 text-[13px] md:text-sm">
             <div class="term-bar">
                 <span class="term-dot bg-[#FF5F57]"></span>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -18,19 +18,26 @@
         <section class="mb-12">
             <p class="mb-3 text-sm text-term">~ $ cat about.md</p>
             <h2 class="sr-only">About Mark van Eijk</h2>
-            <p class="leading-relaxed text-muted">
-                Mark van Eijk is a full-stack Laravel developer and entrepreneur from Nijmegen, the Netherlands.
-                He has been building for the web for more than a decade and works across the entire stack:
-                solid back ends in <x-link href="https://laravel.com">Laravel</x-link> and PHP, interactive front
-                ends with React, Inertia.js and Tailwind CSS, and the infrastructure that keeps it all running.
-                Mark works at <x-link href="https://ux.nl">UX</x-link> and is currently building
-                <x-link href="https://rocketee.rs">Rocketeers</x-link>. He cares about developer experience,
-                performance and simple solutions to complicated problems, and shares as much of his work as
-                possible as open source on <x-link href="https://github.com/markvaneijk">GitHub</x-link> —
-                including this website. He writes about Laravel, PHP and modern web development in his
-                <x-link href="{{ route('posts') }}">posts</x-link>, and he is available for new projects.
-                The fastest way to reach him is by e-mail, or through X and LinkedIn.
-            </p>
+            <div class="space-y-4 leading-relaxed text-muted">
+                <p>
+                    Mark van Eijk is a full-stack Laravel developer and entrepreneur from Nijmegen, the Netherlands.
+                    He has been building for the web for more than a decade and works across the entire stack:
+                    solid back ends in <x-link href="https://laravel.com">Laravel</x-link> and PHP, interactive front
+                    ends with React, Inertia.js and Tailwind CSS, and the infrastructure that keeps it all running.
+                </p>
+                <p>
+                    Mark works at <x-link href="https://ux.nl">UX</x-link> and is currently building
+                    <x-link href="https://rocketee.rs">Rocketeers</x-link>. He cares about developer experience,
+                    performance and simple solutions to complicated problems, and shares as much of his work as
+                    possible as open source on <x-link href="https://github.com/markvaneijk">GitHub</x-link> —
+                    including this website.
+                </p>
+                <p>
+                    He writes about Laravel, PHP and modern web development in his
+                    <x-link href="{{ route('posts') }}">posts</x-link>, and he is available for new projects.
+                    The fastest way to reach him is by e-mail, or through X and LinkedIn.
+                </p>
+            </div>
         </section>
 
         <div class="term mb-12 text-[13px] md:text-sm">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -9,17 +9,7 @@
 
 @push('structured-data')
 <script type="application/ld+json">
-{!! json_encode([
-    '@context' => 'https://schema.org',
-    '@type' => 'BlogPosting',
-    'headline' => $post->title,
-    'description' => $post->excerpt,
-    'url' => $post->url,
-    'datePublished' => $post->published_at->format('Y-m-d'),
-    'dateModified' => ($post->updated_at ?? $post->published_at)->format('Y-m-d'),
-    'author' => ['@id' => url('/').'#mark'],
-    'mainEntityOfPage' => $post->url,
-], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) !!}
+{!! \App\Support\SchemaOrg::blogPosting($post) !!}
 </script>
 @endpush
 

--- a/resources/views/templates/master.blade.php
+++ b/resources/views/templates/master.blade.php
@@ -8,16 +8,16 @@
         <link href="https://fonts.bunny.net/css?family=chakra-petch:600,700|jetbrains-mono:400,500,700&display=swap" rel="stylesheet">
         @vite('resources/css/app.css')
         @env('production')
-        <script src="https://cdn.visitors.now/v.js" data-token="ccbd95ad-850a-4f12-9d3b-6cfdb98c6b96"></script>
+        <script src="https://cdn.visitors.now/v.js" data-token="ccbd95ad-850a-4f12-9d3b-6cfdb98c6b96" defer></script>
         @endenv
     </head>
     <body>
         <header class="px-6 py-5 border-b md:px-10 border-edge">
             <div class="container flex items-baseline justify-between mx-auto md:max-w-xl">
                 <a href="/" class="font-bold"><span class="text-term">$</span> mark-van-eijk<span class="text-flame">_</span></a>
-                <nav class="flex gap-6 text-sm text-muted">
-                    <a href="{{ route('posts') }}" class="transition-colors hover:text-term">/posts</a>
-                    <a href="{{ route('now') }}" class="transition-colors hover:text-term">/now</a>
+                <nav class="flex gap-2 text-sm text-muted">
+                    <a href="{{ route('posts') }}" class="px-2 py-3 -my-3 transition-colors hover:text-term">/posts</a>
+                    <a href="{{ route('now') }}" class="px-2 py-3 -my-3 transition-colors hover:text-term">/now</a>
                 </nav>
             </div>
         </header>

--- a/resources/views/templates/partials/meta.blade.php
+++ b/resources/views/templates/partials/meta.blade.php
@@ -1,4 +1,6 @@
-@php($sections = app()->view->getSections())
+{{-- Inline @section('x', 'y') values arrive pre-escaped by Blade's startSection();
+     decode them here so the {{ }} echoes below escape exactly once. --}}
+@php($sections = array_map(fn ($section) => is_string($section) ? html_entity_decode($section, ENT_QUOTES) : $section, app()->view->getSections()))
 @php($title = isset($sections['title']) ? $sections['title'].' - '.config('app.name') : config('app.name').' - Laravel Developer from Nijmegen, Netherlands')
 @php($description = $sections['description'] ?? 'Mark van Eijk is a full-stack Laravel developer and entrepreneur from Nijmegen, the Netherlands, working with Laravel, React, Inertia and Tailwind CSS.')
 @php($image = $sections['image'] ?? asset('images/mark-van-eijk.png'))
@@ -43,30 +45,5 @@
 <meta name="twitter:image" content="{{ $image }}">
 
 <script type="application/ld+json">
-{!! json_encode([
-    '@context' => 'https://schema.org',
-    '@type' => 'Person',
-    '@id' => url('/').'#mark',
-    'name' => 'Mark van Eijk',
-    'url' => url('/'),
-    'image' => asset('images/mark-van-eijk.png'),
-    'jobTitle' => 'Laravel Developer',
-    'description' => 'Full-stack Laravel developer and entrepreneur from Nijmegen, the Netherlands.',
-    'address' => [
-        '@type' => 'PostalAddress',
-        'addressLocality' => 'Nijmegen',
-        'addressCountry' => 'NL',
-    ],
-    'worksFor' => [
-        '@type' => 'Organization',
-        'name' => 'UX',
-        'url' => 'https://ux.nl',
-    ],
-    'knowsAbout' => ['Laravel', 'PHP', 'React', 'Inertia', 'Tailwind CSS'],
-    'sameAs' => [
-        'https://github.com/markvaneijk',
-        'https://x.com/markvaneijk',
-        'https://linkedin.com/in/markveijk',
-    ],
-], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) !!}
+{!! \App\Support\SchemaOrg::person() !!}
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,4 +34,22 @@ Route::group(['prefix' => 'socials'], function () {
 });
 
 Route::get('posts', PostController::class)->name('posts');
+
+// Legacy blog posts that still earn backlinks (Laracasts, SitePoint, Habr, …)
+// but were removed years ago — 301 them to /posts to preserve link equity.
+foreach ([
+    'use-hhvm-to-speed-up-composer',
+    'whats-new-and-upcoming-in-laravel-4-1',
+    'caching-routes-using-filters-in-laravel-4',
+    'why-you-should-use-mariadb-instead-of-mysql',
+    'the-fastest-way-to-install-laravel',
+    'minify-the-html-output-in-laravel-4',
+    'quick-tip-caching-eloquent-in-laravel-4',
+    'how-to-automatically-protect-your-forms-in-laravel-against-csrf',
+    'laravel-4-all-the-new-good-stuff',
+    'route-patterns-in-laravel',
+] as $legacySlug) {
+    Route::redirect($legacySlug, '/posts', 301);
+}
+
 Route::get('{post}', [PostController::class, 'show'])->where('post', '.*')->name('post');


### PR DESCRIPTION
Implements every code-level fix from the full SEO audit of markvaneijk.com (production) and the redesign branch.

## Pre-deploy blockers fixed

- **JSON-LD was invalid on every page.** The literal `@context` key inside the Blade templates collided with Laravel's `@context` directive, which compiled it into raw PHP inside the JSON. Schema now lives in `App\Support\SchemaOrg` (plain PHP, immune to directive collisions). Verified: Person renders as valid JSON site-wide; BlogPosting verified against a temporary test post (removed after verification). `mainEntityOfPage` also upgraded to the `WebPage` object form Google prefers.
- **SERP snippets showed literal `&#039;`.** Inline `@section('description', "…")` values are pre-escaped by Blade's `startSection()` and were escaped again in the meta partial. The partial now decodes section values once, so titles/descriptions with apostrophes encode exactly once (verified on `/`, `/now`, and a post title containing an apostrophe).
- **`/now` can no longer 500.** The Strava component now guards its API call with try/catch and returns an empty string on failure, mirroring the existing Spotify component. (Production's current 500 on `/now` is this exact failure mode in the old build.)

## Quick wins

- 301 redirects for 10 legacy blog post URLs that still earn backlinks (Laracasts DR 87, SitePoint 86, Habr 88, laravel-news 85, …) but have 404'd for years — recovers existing link equity.
- `Sitemap:` directive added to robots.txt; `/llms.txt` added for AI crawlers.
- `lastmod` on the posts index sitemap entry, derived from the latest post (never fabricated from `now()`).
- Security headers middleware: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`.
- `defer` on the `cdn.visitors.now` analytics script (was parser-blocking in `<head>`).

## Content & UX

- New ~140-word citable About paragraph on the homepage, placed above the terminal widget (first extractable prose passage after the H1 — the top GEO recommendation).
- Fixed 16px horizontal overflow on mobile (the `.glow-field::before` glow bled 40px past the viewport; now bleeds only from `md:` up, plus `overflow-x: clip` on body as a safety net).
- Nav links now have 44px-tall tap areas (padding + negative margin, no visual change); social buttons bumped to ~49px.

## Verified

- Person + BlogPosting JSON-LD parse as valid JSON (temp post round-trip, then removed)
- All legacy slugs 301 → `/posts`; `/nonexistent` still hard-404s
- Security headers present on responses; robots/llms/feed/sitemap all 200
- No mobile horizontal scroll at 390px; desktop layout unchanged
- `php artisan test` passes; `npm run build` compiles cleanly

## Not in this PR (needs you / infra)

- **Deploy production** — it's still serving the pre-redesign build (asset `app-2186c0f0.css`); confirm `APP_URL=https://markvaneijk.com`, `npm run build` in the pipeline, no `public/hot` shipped, and that `public/images/mark-van-eijk.png` deploys (currently 404 in production, breaking the OG image).
- **Publish blog posts** — `content/posts/` is empty; the site has 0 organic keywords (Ahrefs) until content exists.
- Edge-caching public HTML (session cookies currently force `cf-cache-status: DYNAMIC`) — worth discussing, deliberately left out as it touches session/CSRF behavior.
- No SRI hash on `cdn.visitors.now/v.js`: the vendor rotates the file, so a pinned hash would silently break analytics; flagging the security-plugin warning as accepted risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)